### PR TITLE
Port some Python 3.6 changes from the old repo

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,9 +15,11 @@ Ihor Gorobets
 Jeroen Ruigrok van der Werven
 John Eikenberry
 Joongi Kim
+lilydjwg
 Marc Weber
 Michael Doronin
 Neil Schemenauer
+nfnty
 Pedro Algarvio
 Victor Salgado
 Will Gray

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -319,35 +319,35 @@ if s:Python2Syntax()
   syn match   pythonOctError '\<0[oO]\=\o*[8-9]\d*[lL]\=\>' display
   syn match   pythonBinError '\<0[bB][01]*[2-9]\d*[lL]\=\>' display
 
-  syn match   pythonFloat	'\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>' display
-  syn match   pythonFloat	'\<\d\+[eE][+-]\=\d\+[jJ]\=\>' display
-  syn match   pythonFloat	'\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=' display
+  syn match   pythonFloat    '\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>' display
+  syn match   pythonFloat    '\<\d\+[eE][+-]\=\d\+[jJ]\=\>' display
+  syn match   pythonFloat    '\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=' display
 else
   syn match   pythonOctError '\<0[oO]\=\o*\D\+\d*\>' display
   " pythonHexError comes after pythonOctError so that 0xffffl is pythonHexError
   syn match   pythonHexError '\<0[xX]\x*[g-zG-Z]\x*\>' display
   syn match   pythonBinError '\<0[bB][01]*\D\+\d*\>' display
 
-  syn match   pythonHexNumber	'\<0[xX][_0-9a-fA-F]*\x\>' display
+  syn match   pythonHexNumber '\<0[xX][_0-9a-fA-F]*\x\>' display
   syn match   pythonOctNumber '\<0[oO][_0-7]*\o\>' display
   syn match   pythonBinNumber '\<0[bB][_01]*[01]\>' display
 
-  syn match   pythonNumberError	'\<\d[_0-9]*\D\>' display
-  syn match   pythonNumberError	'\<0[_0-9]\+\>' display
-  syn match   pythonNumberError	'\<0_x\S*\>' display
-  syn match   pythonNumberError	'\<0[bBxXoO][_0-9a-fA-F]*_\>' display
-  syn match   pythonNumberError	'\<\d[_0-9]*_\>' display
+  syn match   pythonNumberError '\<\d[_0-9]*\D\>' display
+  syn match   pythonNumberError '\<0[_0-9]\+\>' display
+  syn match   pythonNumberError '\<0_x\S*\>' display
+  syn match   pythonNumberError '\<0[bBxXoO][_0-9a-fA-F]*_\>' display
+  syn match   pythonNumberError '\<\d[_0-9]*_\>' display
   syn match   pythonNumber      '\<\d\>' display
-  syn match   pythonNumber	'\<[1-9][_0-9]*\d\>' display
-  syn match   pythonNumber	'\<\d[jJ]\>' display
-  syn match   pythonNumber	'\<[1-9][_0-9]*\d[jJ]\>' display
+  syn match   pythonNumber      '\<[1-9][_0-9]*\d\>' display
+  syn match   pythonNumber      '\<\d[jJ]\>' display
+  syn match   pythonNumber      '\<[1-9][_0-9]*\d[jJ]\>' display
 
   syn match   pythonOctError '\<0[oO]\=\o*[8-9]\d*\>' display
   syn match   pythonBinError '\<0[bB][01]*[2-9]\d*\>' display
 
-  syn match   pythonFloat	'\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=\>' display
-  syn match   pythonFloat	'\<\d\%([_0-9]*\d\)\=[eE][+-]\=\d\%([_0-9]*\d\)\=[jJ]\=\>' display
-  syn match   pythonFloat	'\<\d\%([_0-9]*\d\)\=\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=' display
+  syn match   pythonFloat    '\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=\>' display
+  syn match   pythonFloat    '\<\d\%([_0-9]*\d\)\=[eE][+-]\=\d\%([_0-9]*\d\)\=[jJ]\=\>' display
+  syn match   pythonFloat    '\<\d\%([_0-9]*\d\)\=\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=' display
 endif
 
 "

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -96,6 +96,7 @@ else
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
+  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
 endif
 
 syn region FunctionParameters start='(\zs' end='\ze)' display contains=
@@ -213,10 +214,15 @@ if s:Python2Syntax()
   syn region pythonUniString  start=+[uU]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 else
   " Python 3 strings
-  syn region pythonString   start=+f\?'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
-  syn region pythonString   start=+f\?"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
-  syn region pythonString   start=+f\?"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
-  syn region pythonString   start=+f\?'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
+  syn region pythonString   start=+'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonString   start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonString   start=+"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
+  syn region pythonString   start=+'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
+
+  syn region pythonFString   start=+[fF]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
+  syn region pythonFString   start=+[fF]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 endif
 
 if s:Python2Syntax()
@@ -267,8 +273,9 @@ if s:Enabled('g:python_highlight_string_format')
     syn match pythonStrFormat '{{\|}}' contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
     syn match pythonStrFormat '{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}' contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
   else
-    syn match pythonStrFormat '{{\|}}' contained containedin=pythonString,pythonRawString
-    syn match pythonStrFormat '{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}' contained containedin=pythonString,pythonRawString
+    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString,pythonFString
+    syn match pythonStrFormat "{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
+    syn region pythonStrInterpRegion start="{"he=e+1,rs=e+1 end="\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}"hs=s-1,re=s-1 extend contained containedin=pythonFString contains=pythonStrInterpRegion,@pythonExpression
   endif
 endif
 
@@ -474,6 +481,8 @@ if v:version >= 508 || !exists('did_python_syn_inits')
     HiLink pythonBytesError         Error
     HiLink pythonBytesEscape        Special
     HiLink pythonBytesEscapeError   Error
+    HiLink pythonFString            String
+    HiLink pythonStrInterpRegion    Special
   endif
 
   HiLink pythonStrFormatting    Special

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -130,7 +130,7 @@ syn match OptionalParameters /\i*\ze=/ display contained
 " Decorators (new in Python 2.4)
 "
 
-syn match   pythonDecorator    '@' display nextgroup=pythonDottedName skipwhite
+syn match   pythonDecorator    '^\s*\zs@' display nextgroup=pythonDottedName skipwhite
 if s:Python2Syntax()
   syn match   pythonDottedName '[a-zA-Z_][a-zA-Z0-9_]*\%(\.[a-zA-Z_][a-zA-Z0-9_]*\)*' display contained nextgroup=FunctionParameters
 else

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -318,28 +318,37 @@ if s:Python2Syntax()
 
   syn match   pythonOctError '\<0[oO]\=\o*[8-9]\d*[lL]\=\>' display
   syn match   pythonBinError '\<0[bB][01]*[2-9]\d*[lL]\=\>' display
+
+  syn match   pythonFloat	'\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>' display
+  syn match   pythonFloat	'\<\d\+[eE][+-]\=\d\+[jJ]\=\>' display
+  syn match   pythonFloat	'\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=' display
 else
-  syn match   pythonHexError '\<0[xX]\x*[g-zG-Z]\x*\>' display
   syn match   pythonOctError '\<0[oO]\=\o*\D\+\d*\>' display
+  " pythonHexError comes after pythonOctError so that 0xffffl is pythonHexError
+  syn match   pythonHexError '\<0[xX]\x*[g-zG-Z]\x*\>' display
   syn match   pythonBinError '\<0[bB][01]*\D\+\d*\>' display
 
-  syn match   pythonHexNumber '\<0[xX]\x\+\>' display
-  syn match   pythonOctNumber '\<0[oO]\o\+\>' display
-  syn match   pythonBinNumber '\<0[bB][01]\+\>' display
+  syn match   pythonHexNumber	'\<0[xX][_0-9a-fA-F]*\x\>' display
+  syn match   pythonOctNumber '\<0[oO][_0-7]*\o\>' display
+  syn match   pythonBinNumber '\<0[bB][_01]*[01]\>' display
 
-  syn match   pythonNumberError '\<\d\+\D\>' display
-  syn match   pythonNumberError '\<0\d\+\>' display
+  syn match   pythonNumberError	'\<\d[_0-9]*\D\>' display
+  syn match   pythonNumberError	'\<0[_0-9]\+\>' display
+  syn match   pythonNumberError	'\<0_x\S*\>' display
+  syn match   pythonNumberError	'\<0[bBxXoO][_0-9a-fA-F]*_\>' display
+  syn match   pythonNumberError	'\<\d[_0-9]*_\>' display
   syn match   pythonNumber      '\<\d\>' display
-  syn match   pythonNumber      '\<[1-9]\d\+\>' display
-  syn match   pythonNumber      '\<\d\+[jJ]\>' display
+  syn match   pythonNumber	'\<[1-9][_0-9]*\d\>' display
+  syn match   pythonNumber	'\<\d[jJ]\>' display
+  syn match   pythonNumber	'\<[1-9][_0-9]*\d[jJ]\>' display
 
   syn match   pythonOctError '\<0[oO]\=\o*[8-9]\d*\>' display
   syn match   pythonBinError '\<0[bB][01]*[2-9]\d*\>' display
-endif
 
-syn match   pythonFloat '\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>' display
-syn match   pythonFloat '\<\d\+[eE][+-]\=\d\+[jJ]\=\>' display
-syn match   pythonFloat '\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=' display
+  syn match   pythonFloat	'\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=\>' display
+  syn match   pythonFloat	'\<\d\%([_0-9]*\d\)\=[eE][+-]\=\d\%([_0-9]*\d\)\=[jJ]\=\>' display
+  syn match   pythonFloat	'\<\d\%([_0-9]*\d\)\=\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=' display
+endif
 
 "
 " Builtin objects and types

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,6 +11,8 @@
 with break continue del exec return pass print raise global assert lambda yield
 for while if elif else import from as try except finally and in is not or
 
+from test import var as name
+
 yield from
 
 def functionname
@@ -61,11 +63,13 @@ RuntimeWarning FutureWarning ImportWarning UnicodeWarning
 
 # Numbers
 
-0 1 2 9 10 0x1f .3 12.34 0j 0j 34.2E-3 0b10 0o77 1023434 0x0
+0 1 2 9 10 0x1f .3 12.34 0j 124j 34.2E-3 0b10 0o77 1023434 0x0
+1_1 1_1.2_2 1_2j 0x_1f 0x1_f 34_56e-3 34_56e+3_1 0o7_7
 
 # Erroneous numbers
 
-077 100L 0xfffffffL 0L 08 0xk 0x  0b102 0o78 0o123LaB
+077 100L 0xfffffffL 0L 08 0xk 0x 0b102 0o78 0o123LaB
+0_ 0_1 0_x1f 0x1f_ 0_b77 0b77_ .2_ 1_j
 
 # Strings
 
@@ -102,6 +106,10 @@ b"{0.name!r:b} {0[n]} {name!s:  } {{test}} {{}} {} {.__len__:s}"
 
 "${test} ${test ${test}aname $$$ $test+nope"
 b"${test} ${test ${test}aname $$$ $test+nope"
+
+f"{var}...{arr[123]} normal {var['{'] // 0xff} \"xzcb\" 'xzcb' {var['}'] + 1} text"
+f"{expr1 if True or False else expr2} wow {','.join(c.lower() for c in 'asdf')}"
+f"hello {expr:.2f} yes {(lambda: 0b1)():#03x} lol {var!r}"
 
 # Doctests.
 


### PR DESCRIPTION
As said in https://github.com/vim-python/python-syntax/issues/2#issuecomment-280552629, I've ported f-strings, underscores in numbers and matrix multiplication operator support here.