### PR TITLE
Add global variable to highlight self and cls from propasal 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ let g:python_highlight_all = 1
 | `g:python_highlight_indent_errors`            | Highlight indentation errors                                   | `0`     |
 | `g:python_highlight_space_errors`             | Highlight trailing spaces                                      | `0`     |
 | `g:python_highlight_doctests`                 | Highlight doc-tests                                            | `0`     |
+| `g:python_highlight_class_vars`               | Highlight class variables `self` and `cls`                     | `0`     |
 | `g:python_highlight_all`                      | Enable all highlight options above, except for previously set. | `0`     |
 | `g:python_highlight_file_headers_as_comments` | Highlight shebang and coding headers as comments               | `0`     |
 | `g:python_slow_sync`                          | Disable for slow machines                                      | `1`     |

--- a/doc/python-syntax.txt
+++ b/doc/python-syntax.txt
@@ -86,6 +86,9 @@ following command to your `~/.config/nvim/init.vim` or `~/.vimrc`: >
 `g:python_highlight_doctests` (default `0`)
     Highlight doc-tests
 
+`g:python_highlight_class_vars` (default `0`)
+    Highlight class variables `self` and `cls`
+
 `g:python_highlight_all` (default `0`)
     Enable all highlight options above, except for previously set.
 

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -52,14 +52,13 @@ if s:Enabled('g:python_highlight_all')
   call s:EnableByDefault('g:python_highlight_space_errors')
   call s:EnableByDefault('g:python_highlight_doctests')
   call s:EnableByDefault('g:python_print_as_function')
+  call s:EnableByDefault('g:python_highlight_class_vars')
 endif
 
 "
 " Keywords
 "
 
-syn keyword pythonInstanceVariable self
-syn keyword pythonClassVariable cls
 syn keyword pythonStatement     break continue del
 syn keyword pythonStatement     exec return
 syn keyword pythonStatement     pass yield
@@ -68,6 +67,9 @@ syn keyword pythonStatement     global assert
 syn keyword pythonStatement     lambda
 syn keyword pythonStatement     with
 syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
+if s:Enabled('g:python_highlight_class_vars')
+  syn keyword pythonClassVar    self cls
+endif
 syn keyword pythonRepeat        for while
 syn keyword pythonConditional   if elif else
 syn keyword pythonException     try except finally
@@ -102,8 +104,7 @@ syn region FunctionParameters start='(\zs' end='\ze)' display contains=
             \ FunctionParameters,
             \ OptionalParameters,
             \ pythonRepeat,
-            \ pythonInstanceVariable,
-            \ pythonClassVariable,
+            \ pythonClassVar,
             \ pythonConditional,
             \ pythonComment,
             \ pythonOperator,
@@ -125,7 +126,7 @@ syn region FunctionParameters start='(\zs' end='\ze)' display contains=
             \ pythonNone,
             \ pythonBuiltinFunc,
             \ pythonBoolean nextgroup=pythonRaiseFromStatement display contained
-syn match OptionalParameters /\i*\ze=/ display contained
+syn match OptionalParameters /\i\+\ze=/ display contained
 "
 " Decorators (new in Python 2.4)
 "
@@ -486,9 +487,8 @@ if v:version >= 508 || !exists('did_python_syn_inits')
   HiLink pythonBuiltinFunc      Function
 
   HiLink pythonExClass          Structure
-  HiLink pythonInstanceVariable htmlTagN
-  HiLink pythonClassVariable htmlTagN
-  HiLink OptionalParameters htmlTagN
+  HiLink pythonClassVar         Identifier
+  HiLink OptionalParameters     Identifier
 
   delcommand HiLink
 endif


### PR DESCRIPTION
Enclosed self and cls variables highlight in if statement as mentioned in #7.
By default set to 0.
With g:python_highlight_all enabled g:python_highlight_self_cls set to 1.