### PR TITLE
Add highlight for extra operators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ let g:python_highlight_all = 1
 | `g:python_highlight_space_errors`             | Highlight trailing spaces                                      | `0`     |
 | `g:python_highlight_doctests`                 | Highlight doc-tests                                            | `0`     |
 | `g:python_highlight_class_vars`               | Highlight class variables `self` and `cls`                     | `0`     |
+| `g:python_highlight_extra_operators`          | Highlight extra operators                                      | `0`     |
 | `g:python_highlight_all`                      | Enable all highlight options above, except for previously set. | `0`     |
 | `g:python_highlight_file_headers_as_comments` | Highlight shebang and coding headers as comments               | `0`     |
 | `g:python_slow_sync`                          | Disable for slow machines                                      | `1`     |

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -53,6 +53,7 @@ if s:Enabled('g:python_highlight_all')
   call s:EnableByDefault('g:python_highlight_doctests')
   call s:EnableByDefault('g:python_print_as_function')
   call s:EnableByDefault('g:python_highlight_class_vars')
+  call s:EnableByDefault('g:python_highlight_extra_operators')
 endif
 
 "
@@ -81,6 +82,9 @@ syn keyword pythonImport        import
 syn match pythonIdentifier      '\v[a-zA-Z_][a-zA-Z0-9_]*' nextgroup=pythonFunctionArgs
 syn match pythonRaiseFromStatement      '\<from\>'
 syn match pythonImport          '^\s*\zsfrom\>'
+if s:Enabled('g:python_highlight_extra_operators')
+  syn match pythonExtraOperator '[-+\*/%<>^&|~!=]' display
+endif
 
 
 
@@ -97,10 +101,10 @@ else
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
-  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
+  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonExtraOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
 endif
 
-syn region pythonFunctionArgs start='('rs=s+1 end=')'re=e-1 contains=pythonFunctionArgs,pythonFunctionKwargs,pythonRepeat,pythonClassVar,pythonConditional,pythonComment,pythonOperator,pythonNumber,pythonNumberError,pythonFloat,pythonHexNumber,pythonStatement,pythonOctNumber,pythonString,pythonRawString,pythonUniString,pythonExClass,pythonUniRawString,pythonNumber,pythonRawString,pythonBytes,pythonBuiltinObj,pythonNone,pythonBuiltinFunc,pythonBoolean nextgroup=pythonRaiseFromStatement display contained
+syn region pythonFunctionArgs start='('rs=s+1 end=')'re=e-1 contains=pythonFunctionArgs,pythonFunctionKwargs,pythonRepeat,pythonClassVar,pythonConditional,pythonComment,pythonOperator,pythonExtraOperator,pythonNumber,pythonNumberError,pythonFloat,pythonHexNumber,pythonStatement,pythonOctNumber,pythonString,pythonRawString,pythonUniString,pythonExClass,pythonUniRawString,pythonNumber,pythonRawString,pythonBytes,pythonBuiltinObj,pythonNone,pythonBuiltinFunc,pythonBoolean nextgroup=pythonRaiseFromStatement display contained
 syn match pythonFunctionKwargs /\i\+\ze=/ display contained
 "
 " Decorators (new in Python 2.4)
@@ -400,6 +404,7 @@ if v:version >= 508 || !exists('did_python_syn_inits')
   HiLink pythonRepeat           Repeat
   HiLink pythonException        Exception
   HiLink pythonOperator         Operator
+  HiLink pythonExtraOperator    Operator
 
   HiLink pythonDecorator        Define
   HiLink pythonDottedName       Function


### PR DESCRIPTION
Simplest possible solution for this proposal, will match any number of any characters in `-+\*/%<>^&|~!=` where `\*` is just `*`. Now it can match any of bitwise, comparison, extended assignment operators. Am i missing anything? But as said it will match any number of characters, should we update Error section for any possible error like `<=>`, `=>` etc or it would be too verbose. And if you type something like this you just don't know python, and we here create syntax highlighting not an helper for newbies? But obviosly it will help to find misstypes. 

Needs better description in README. I don't know how to describe this highlight group properly.
