### PR TITLE
separate pythonClassName from pythonFunction

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -53,6 +53,7 @@ if s:Enabled('g:python_highlight_all')
   call s:EnableByDefault('g:python_highlight_space_errors')
   call s:EnableByDefault('g:python_highlight_doctests')
   call s:EnableByDefault('g:python_print_as_function')
+  call s:EnableByDefault('g:python_highlight_class_names')
   call s:EnableByDefault('g:python_highlight_class_vars')
   call s:EnableByDefault('g:python_highlight_operators')
 endif
@@ -64,9 +65,10 @@ endif
 syn keyword pythonStatement     break continue del return pass yield global assert lambda with
 syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
-syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-syn match   pythonClassName    '[:upper:]*' display contained
-
+if s:Enabled('g:python_highlight_class_names')
+    syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
+    syn match   pythonClassName    '^[:upper:]\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
+endif
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls
 endif
@@ -93,7 +95,6 @@ else
   syn match   pythonStatement   '\v\.@<!<await>'
   syn match   pythonFunction    '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
-  syn match   pythonStatement   '\<async\s\+class\>' nextgroup=pythonClassName skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
   syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -65,7 +65,8 @@ syn keyword pythonStatement     break continue del return pass yield global asse
 syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
 syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
+" for all developers, commented out CamelCase regex for className
+"syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls
 endif

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -65,8 +65,8 @@ syn keyword pythonStatement     break continue del return pass yield global asse
 syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
 syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-" for all developers, commented out CamelCase regex for className
-"syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
+syn match   pythonClassName    '[:upper:]*' display contained
+
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls
 endif
@@ -88,13 +88,12 @@ if s:Python2Syntax()
   syn keyword pythonStatement   exec
   syn keyword pythonImport      as
   syn match   pythonFunction    '[a-zA-Z_][a-zA-Z0-9_]*' display contained
-  syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
 else
   syn keyword pythonStatement   as nonlocal
   syn match   pythonStatement   '\v\.@<!<await>'
   syn match   pythonFunction    '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
-  syn match   pythonClassName   '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
+  syn match   pythonStatement   '\<async\s\+class\>' nextgroup=pythonClassName skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
   syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -63,7 +63,9 @@ endif
 
 syn keyword pythonStatement     break continue del return pass yield global assert lambda with
 syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
-syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
+syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
+syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
+syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls
 endif
@@ -407,6 +409,7 @@ if v:version >= 508 || !exists('did_python_syn_inits')
   HiLink pythonRaiseFromStatement   Statement
   HiLink pythonImport           Include
   HiLink pythonFunction         Function
+  HiLink pythonClassName        Structure
   HiLink pythonConditional      Conditional
   HiLink pythonRepeat           Repeat
   HiLink pythonException        Exception

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -67,7 +67,7 @@ syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
 if s:Enabled('g:python_highlight_class_names')
     syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-    syn match   pythonClassName    '^[:upper:]\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
+    syn match   pythonClassName    '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
 endif
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -67,7 +67,7 @@ syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
 if s:Enabled('g:python_highlight_class_names')
     syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-    syn match   pythonClassName    '[:upper:]\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
+    syn match   pythonClassName    '\%([[:upper:]][^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
 endif
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -88,10 +88,12 @@ if s:Python2Syntax()
   syn keyword pythonStatement   exec
   syn keyword pythonImport      as
   syn match   pythonFunction    '[a-zA-Z_][a-zA-Z0-9_]*' display contained
+  syn match   pythonClassName    '[A-Z][a-zA-Z0-9_]*' display contained
 else
   syn keyword pythonStatement   as nonlocal
   syn match   pythonStatement   '\v\.@<!<await>'
   syn match   pythonFunction    '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
+  syn match   pythonClassName   '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -67,7 +67,7 @@ syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def nextgroup=pythonFunction skipwhite
 if s:Enabled('g:python_highlight_class_names')
     syn keyword pythonStatement     class nextgroup=pythonClassName skipwhite
-    syn match   pythonClassName    '\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
+    syn match   pythonClassName    '[:upper:]\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*' display contained
 endif
 if s:Enabled('g:python_highlight_class_vars')
   syn keyword pythonClassVar    self cls

--- a/tests/test.py
+++ b/tests/test.py
@@ -22,7 +22,8 @@ class Classname
 class classname
 def функция
 class Класс
-class функция
+class класс
+
 
 # Keywords: Python 2
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,8 +19,10 @@ yield from
 
 def functionname
 class Classname
+class classname
 def функция
 class Класс
+class функция
 
 # Keywords: Python 2
 


### PR DESCRIPTION
Ref: #18 
This is the enhancement to separate classname from function name.
about regexp of `pythonClassName`, I intend to make it compliant with pep.