### PR TITLE
Split builtin objects / types

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ let g:python_highlight_all = 1
 | `b:python_version_2`                          | Python 2 mode (buffer local)                                   | `0`     |
 | `g:python_highlight_builtins`                 | Highlight builtin functions and objects                        | `0`     |
 | `g:python_highlight_builtin_objs`             | Highlight builtin objects only                                 | `0`     |
+| `g:python_highlight_builtin_types`            | Highlight builtin types only                                   | `0`     |
 | `g:python_highlight_builtin_funcs`            | Highlight builtin functions only                               | `0`     |
 | `g:python_highlight_builtin_funcs_kwarg`      | Highlight builtin functions when used as kwarg                 | `1`     |
 | `g:python_highlight_exceptions`               | Highlight standard exceptions                                  | `0`     |

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -93,7 +93,7 @@ else
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
-  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonNone,pythonBuiltinObj,pythonBuiltinFunc,pythonBuiltinType
+  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonNone,pythonSingleton,pythonBuiltinObj,pythonBuiltinFunc,pythonBuiltinType
 endif
 
 
@@ -337,7 +337,7 @@ endif
 if s:Enabled('g:python_highlight_builtin_objs')
   syn keyword pythonNone        None
   syn keyword pythonBoolean     True False
-  syn keyword pythonBuiltinObj  Ellipsis NotImplemented
+  syn keyword pythonSingleton   Ellipsis NotImplemented
   syn keyword pythonBuiltinObj  __debug__ __doc__ __file__ __name__ __package__
   syn keyword pythonBuiltinObj  __loader__ __spec__ __path__ __cached__
 endif
@@ -479,6 +479,7 @@ if v:version >= 508 || !exists('did_python_syn_inits')
 
   HiLink pythonBoolean          Boolean
   HiLink pythonNone             Constant
+  HiLink pythonSingleton        Constant
 
   HiLink pythonBuiltinObj       Identifier
   HiLink pythonBuiltinFunc      Function

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -44,6 +44,7 @@ if s:Enabled('g:python_highlight_all')
   if s:Enabled('g:python_highlight_builtins')
     call s:EnableByDefault('g:python_highlight_builtin_objs')
     call s:EnableByDefault('g:python_highlight_builtin_funcs')
+    call s:EnableByDefault('g:python_highlight_builtin_types')
   endif
   call s:EnableByDefault('g:python_highlight_exceptions')
   call s:EnableByDefault('g:python_highlight_string_formatting')
@@ -92,7 +93,7 @@ else
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
-  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonNone,pythonBuiltinObj,pythonBuiltinFunc
+  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonNone,pythonBuiltinObj,pythonBuiltinFunc,pythonBuiltinType
 endif
 
 
@@ -330,14 +331,13 @@ else
 endif
 
 "
-" Builtin objects and types
+" Builtin objects
 "
 
 if s:Enabled('g:python_highlight_builtin_objs')
   syn keyword pythonNone        None
   syn keyword pythonBoolean     True False
   syn keyword pythonBuiltinObj  Ellipsis NotImplemented
-  syn match pythonBuiltinObj    '\v\.@<!<%(object|bool|int|float|tuple|str|list|dict|set|frozenset|bytearray|bytes)>'
   syn keyword pythonBuiltinObj  __debug__ __doc__ __file__ __name__ __package__
   syn keyword pythonBuiltinObj  __loader__ __spec__ __path__ __cached__
 endif
@@ -367,6 +367,15 @@ if s:Enabled('g:python_highlight_builtin_funcs')
   execute s:funcs_re . ''''
   unlet s:funcs_re
 endif
+
+"
+" Builtin types
+"
+
+if s:Enabled('g:python_highlight_builtin_types')
+  syn match pythonBuiltinType    '\v\.@<!<%(object|bool|int|float|tuple|str|list|dict|set|frozenset|bytearray|bytes)>'
+endif
+
 
 "
 " Builtin exceptions and warnings
@@ -471,8 +480,9 @@ if v:version >= 508 || !exists('did_python_syn_inits')
   HiLink pythonBoolean          Boolean
   HiLink pythonNone             Constant
 
-  HiLink pythonBuiltinObj       Structure
+  HiLink pythonBuiltinObj       Identifier
   HiLink pythonBuiltinFunc      Function
+  HiLink pythonBuiltinType      Structure
 
   HiLink pythonExClass          Structure
   HiLink pythonClassVar         Identifier

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -92,7 +92,7 @@ else
   syn match   pythonStatement   '\<async\s\+def\>' nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   '\<async\s\+with\>'
   syn match   pythonStatement   '\<async\s\+for\>'
-  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
+  syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonNone,pythonBuiltinObj,pythonBuiltinFunc
 endif
 
 


### PR DESCRIPTION
Create new group for builtin types (`object`, `bool`, ...) pythonBultinType and corresponding flag g:python_highlight_builtin_types

Create new group for singleton objects (`Ellipsis` and `NotImplemented`) pythonSingleton 

also includes https://github.com/vim-python/python-syntax/pull/54