### PR TITLE
Add `mcs` to `self` and `cls` class variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features
   * New exceptions and builtins
   * Doctests
   * `@decorator` syntax
-  * Class variables such as `self` and `cls`
+  * Class variables such as `self`, `cls` and `mcs`
   * Operators
 * Highlighting of the following errors:
   * Invalid symbols in source file
@@ -72,7 +72,7 @@ let g:python_highlight_all = 1
 | `g:python_highlight_space_errors`             | Highlight trailing spaces                                      | `0`     |
 | `g:python_highlight_doctests`                 | Highlight doc-tests                                            | `0`     |
 | `g:python_highlight_func_calls`               | Highlight functions calls                                      | `0`     |
-| `g:python_highlight_class_vars`               | Highlight class variables `self` and `cls`                     | `0`     |
+| `g:python_highlight_class_vars`               | Highlight class variables `self`, `cls` and `mcs`              | `0`     |
 | `g:python_highlight_operators`                | Highlight all operators                                        | `0`     |
 | `g:python_highlight_all`                      | Enable all highlight options above, except for previously set. | `0`     |
 | `g:python_highlight_file_headers_as_comments` | Highlight shebang and coding headers as comments               | `0`     |

--- a/doc/python-syntax.txt
+++ b/doc/python-syntax.txt
@@ -21,7 +21,7 @@ Features
   * New exceptions and builtins
   * Doctests
   * `@decorator` syntax
-  * Class variables such as `self` and `cls`
+  * Class variables such as `self`, `cls` and `mcs`
   * Operators
 * Highlighting of the following errors:
   * Invalid symbols in source file
@@ -96,7 +96,7 @@ following command to your `~/.config/nvim/init.vim` or `~/.vimrc`: >
     Highlight functions calls
 
 `g:python_highlight_class_vars` (default `0`)
-    Highlight class variables `self` and `cls`
+    Highlight class variables `self`, `cls` and `mcs`
 
 `g:python_highlight_operators` (default `0`)
     Highlight all operators

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -76,7 +76,7 @@ syn keyword pythonStatement     break continue del return pass yield global asse
 syn keyword pythonStatement     raise nextgroup=pythonExClass skipwhite
 syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
 if s:Enabled('g:python_highlight_class_vars')
-    syn keyword pythonClassVar    self cls
+    syn keyword pythonClassVar    self cls mcs
 endif
 syn keyword pythonRepeat        for while
 syn keyword pythonConditional   if elif else


### PR DESCRIPTION
Usually progammers user mcs or cls in metaclasses
https://stackoverflow.com/questions/100003/what-are-metaclasses-in-python

This PR adds highlighting for `mcs`